### PR TITLE
feat: add GitHub Actions

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,12 @@
+name: automatically add to project board
+on:
+    issues:
+        types: [opened, transferred, reopened, unlocked]
+    pull_request:
+        types: [opened, edited, synchronize, auto_merge_enabled, reopened]
+
+jobs:
+    add_to_project:
+        uses: road86/.github/.github/workflows/add-to-project.yml@main
+        secrets:
+            TOKEN: ${{ secrets.ROBOT_TOKEN }}

--- a/.github/workflows/check-pr-title-and-add-labels.yml
+++ b/.github/workflows/check-pr-title-and-add-labels.yml
@@ -1,0 +1,16 @@
+name: check PR title and label appropriately
+on:
+    pull_request:
+        types: [opened, edited, synchronize, auto_merge_enabled, reopened]
+        branches:
+            - main
+
+jobs:
+    check_PR_title:
+        uses: road86/.github/.github/workflows/check-pr-title.yml@main
+        secrets:
+            TOKEN: ${{ secrets.ROBOT_TOKEN }}
+    add_labels:
+        uses: road86/.github/.github/workflows/apply-labels-to-pr.yml@main
+        secrets:
+            TOKEN: ${{ secrets.ROBOT_TOKEN }}

--- a/.github/workflows/synchronise-labels.yml
+++ b/.github/workflows/synchronise-labels.yml
@@ -1,0 +1,20 @@
+name: Set Repo Label List
+
+on:
+    workflow_dispatch:
+    schedule:
+        - cron: '00 00 * * *'
+
+jobs:
+    labeler:
+        runs-on: ubuntu-latest
+        steps:
+            - name: checkout
+              uses: actions/checkout@v2
+            - name: synchronize labels
+              uses: julbme/gh-action-manage-label@v1
+              with:
+                  from: https://raw.githubusercontent.com/road86/.github/main/.github/labels.yml
+                  skip-delete: true
+              env:
+                  GITHUB_TOKEN: ${{ secrets.ROBOT_TOKEN  }}


### PR DESCRIPTION
## Description

Adding the initial GitHub Actions for:

1. automatically putting newly created issues and PRs on our project board
2. checking the repo labels are in sync with our .github repo nightly (or on manual dispatch)
3. checking PR titles are "conventional" and automatically labelling them

## TODO

- [x] In a future PR I will add a GitHub Action to automatically lint, build and run tests

## Checklist

- [x] I have read the road86 Contribution Guide.
- [x] I have checked all commit message styles match the requested structure.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.