### PR TITLE
fix: Correctly deal with medival records

### DIFF
--- a/prep_dash/prep_data.py
+++ b/prep_dash/prep_data.py
@@ -95,7 +95,7 @@ bahis_preped_data = bahis_sourcedata[['basic_info_date',
                                         'patient_info_sick_number',
                                         'patient_info_dead_number']]
 
-bahis_preped_data['basic_info_date'] = pd.to_datetime(bahis_preped_data['basic_info_date'])
+bahis_preped_data['basic_info_date'] = pd.to_datetime(bahis_preped_data['basic_info_date'],errors = 'coerce')
 
 bahis_preped_data['basic_info_date'] = bahis_preped_data['basic_info_date'].apply(lambda x: x.date())
 


### PR DESCRIPTION
## Description

Dealing correctly with conversion errors of visits from medival times such as `1202-03-19`. Due to https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#timestamp-limitations we cannot correctly convert this in pandas to datetime.


